### PR TITLE
OCT-8: dirty workaround

### DIFF
--- a/src/Controller/ListProductsAction.php
+++ b/src/Controller/ListProductsAction.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace App\Controller;
 
+use Akeneo\Pim\ApiClient\Exception\HttpException;
 use App\Query\Locale\GuessCurrentLocaleQuery;
 use App\Query\Product\FetchProductsQuery;
+use App\Storage\AccessTokenStorageInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment as TwigEnvironment;
 
 final class ListProductsAction
@@ -17,18 +21,30 @@ final class ListProductsAction
         private TwigEnvironment $twig,
         private GuessCurrentLocaleQuery $guessCurrentLocaleQuery,
         private FetchProductsQuery $fetchProductsQuery,
+        private RouterInterface $router,
+        private AccessTokenStorageInterface $accessTokenStorage,
     ) {
     }
 
     #[Route('/products', name: 'products', methods: ['GET'])]
     public function __invoke(Request $request): Response
     {
-        $locale = ($this->guessCurrentLocaleQuery)();
+        try {
+            $locale = ($this->guessCurrentLocaleQuery)();
+            $products = ($this->fetchProductsQuery)($locale);
+        } catch (HttpException $e){
+            $this->accessTokenStorage->clear();
+            $session = $request->getSession();
+
+            return new RedirectResponse($this->router->generate('welcome', [
+                'pim_url' => $session->get('pim_url'),
+            ]));
+        }
 
         return new Response(
             $this->twig->render('products.html.twig', [
                 'locale' => $locale,
-                'products' => ($this->fetchProductsQuery)($locale),
+                'products' => $products,
             ])
         );
     }

--- a/src/Storage/AccessTokenSessionStorage.php
+++ b/src/Storage/AccessTokenSessionStorage.php
@@ -32,4 +32,9 @@ class AccessTokenSessionStorage implements AccessTokenStorageInterface
     {
         $this->requestStack->getSession()->set(self::ACCESS_TOKEN_SESSION_KEY, $accessToken);
     }
+
+    public function clear(): void
+    {
+        $this->requestStack->getSession()->remove(self::ACCESS_TOKEN_SESSION_KEY);
+    }
 }

--- a/src/Storage/AccessTokenStorageInterface.php
+++ b/src/Storage/AccessTokenStorageInterface.php
@@ -9,4 +9,6 @@ interface AccessTokenStorageInterface
     public function getAccessToken(): ?string;
 
     public function setAccessToken(string $accessToken): void;
+
+    public function clear(): void;
 }


### PR DESCRIPTION
I'm catching every exception, even errors not related to authentication, this is bad.
We should only clear the session and start over when the HTTP error is `401`, meaning that the token is revoked or invalid.