### PR TITLE
CXP-1114: manage APP_SECRET during deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
           command: |
             export GCP_APP_NAME=demo-app-pr-${CIRCLE_PULL_REQUEST##*/}
             export GCP_APP_VERSION=${CIRCLE_SHA1}
+            export APP_SECRET=${DEV_SECRET}
             export AKENEO_CLIENT_ID=<< pipeline.parameters.akeneo_client_id >>
             export AKENEO_CLIENT_SECRET=<< pipeline.parameters.akeneo_client_secret >>
             make terraform.deploy.application
@@ -143,6 +144,7 @@ jobs:
           command: |
             export GCP_APP_NAME=demo-app
             export GCP_APP_VERSION=${CIRCLE_SHA1}
+            export APP_SECRET=${PROD_SECRET}
             export AKENEO_CLIENT_ID=${PROD_CLIENT_ID}
             export AKENEO_CLIENT_SECRET=${PROD_CLIENT_SECRET}
             make terraform.deploy.application

--- a/infra/terraform.mk
+++ b/infra/terraform.mk
@@ -54,6 +54,9 @@ endif
 
 .PHONY: deploy.check.application
 deploy.check.application:
+ifndef APP_SECRET
+	$(error APP_SECRET is undefined)
+endif
 ifndef AKENEO_CLIENT_ID
 	$(error AKENEO_CLIENT_ID is undefined)
 endif
@@ -78,6 +81,7 @@ terraform.deploy.application: TF_VAR_gcp_project_id = $(GCP_PROJECT)
 terraform.deploy.application: TF_VAR_gcp_region = $(GCP_REGION)
 terraform.deploy.application: TF_VAR_app_name = $(GCP_APP_NAME)
 terraform.deploy.application: TF_VAR_app_version = $(GCP_APP_VERSION)
+terraform.deploy.application: TF_VAR_app_secret = $(APP_SECRET)
 terraform.deploy.application: TF_VAR_app_client_id = $(AKENEO_CLIENT_ID)
 terraform.deploy.application: TF_VAR_app_client_secret = $(AKENEO_CLIENT_SECRET)
 terraform.deploy.application: export DOCKER_IMAGE_NAME ?= $(GCP_DOCKER_IMAGE_NAME)

--- a/infra/terraform/application/app.tf
+++ b/infra/terraform/application/app.tf
@@ -18,6 +18,10 @@ resource "google_cloud_run_service" "app" {
           name  = "AKENEO_CLIENT_SECRET"
           value = var.app_client_secret
         }
+        env {
+          name  = "APP_SECRET"
+          value = var.app_secret
+        }
       }
     }
 

--- a/infra/terraform/application/variables.tf
+++ b/infra/terraform/application/variables.tf
@@ -27,6 +27,11 @@ variable "app_version" {
   default = "latest"
 }
 
+variable "app_secret" {
+  type    = string
+  default = "28d8c8cc382a2278771b95204733f09a"
+}
+
 variable "app_client_id" {
   type = string
 }


### PR DESCRIPTION
`APP_SECRET`, used for encrypting the cookie, should be stored secretly and injected during the deployment.