### PR TITLE
OCT-32: Handle case with products without a family

### DIFF
--- a/src/Query/FetchProductsQuery.php
+++ b/src/Query/FetchProductsQuery.php
@@ -70,9 +70,10 @@ final class FetchProductsQuery
         $products = [];
 
         foreach ($rawProducts as $rawProduct) {
-            $rawFamily = $families[$rawProduct['family']];
+            $rawFamily = $families[$rawProduct['family']] ?? null;
+            $rawFamilyAttributeAsLabel = null !== $rawFamily ? $rawFamily['attribute_as_label'] : null;
 
-            $label = $this->findLabel($rawFamily['attribute_as_label'], $rawProduct, $locale, $scope);
+            $label = $this->findLabel($rawFamilyAttributeAsLabel, $rawProduct, $locale, $scope);
 
             $values = [];
 
@@ -136,9 +137,9 @@ final class FetchProductsQuery
     /**
      * @param RawProduct $product
      */
-    private function findLabel(string $attributeAsLabel, array $product, string $locale, ?string $scope): string
+    private function findLabel(?string $attributeAsLabel, array $product, string $locale, ?string $scope): string
     {
-        if (!isset($product['values'][$attributeAsLabel])) {
+        if (null === $attributeAsLabel || !isset($product['values'][$attributeAsLabel])) {
             return '['.$product['identifier'].']';
         }
 


### PR DESCRIPTION
It should be impossible, I think, but we received products without a family, see the logs:

![Screenshot_2022-03-10_17-09-47](https://user-images.githubusercontent.com/1421130/157706010-e4c572e3-fe8b-4460-a136-bfab6ca52db6.png)
![Screenshot_2022-03-10_17-12-46](https://user-images.githubusercontent.com/1421130/157706151-7d32b6f6-fab5-44ad-b934-9aae7082d8ef.png)
![Screenshot_2022-03-10_17-08-58](https://user-images.githubusercontent.com/1421130/157706021-c9349cb4-c317-4276-90f2-0aadc873f5d8.png)

I updated the code so we can fallback on the product code instead of the label when it happens.