### PR TITLE
OCT-32: Fix error when a product is empty

### DIFF
--- a/tests/Fixtures/responses/get-product-empty.json
+++ b/tests/Fixtures/responses/get-product-empty.json
@@ -1,0 +1,34 @@
+{
+  "identifier": "empty",
+  "enabled": true,
+  "family": null,
+  "categories": [],
+  "groups": [],
+  "parent": null,
+  "values": [],
+  "created": "2022-02-07T13:40:56+00:00",
+  "updated": "2022-02-07T15:58:20+00:00",
+  "associations": {
+    "PACK": {
+      "products": [],
+      "product_models": [],
+      "groups": []
+    },
+    "UPSELL": {
+      "products": [],
+      "product_models": [],
+      "groups": []
+    },
+    "X_SELL": {
+      "products": [],
+      "product_models": [],
+      "groups": []
+    },
+    "SUBSTITUTION": {
+      "products": [],
+      "product_models": [],
+      "groups": []
+    }
+  },
+  "quantified_associations": {}
+}

--- a/tests/Fixtures/responses/get-products-empty.json
+++ b/tests/Fixtures/responses/get-products-empty.json
@@ -1,0 +1,49 @@
+{
+  "_links": {
+    "self": {
+      "href": "https://example.com/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=%7B%22enabled%22:%5B%7B%22operator%22:%22%3D%22,%22value%22:true%7D%5D,%22family%22:%5B%7B%22operator%22:%22IN%22,%22value%22:%5B%22accessories%22%5D%7D%5D%7D&locales=en_US"
+    },
+    "first": {
+      "href": "https://example.com/api/rest/v1/products?page=1&with_count=false&pagination_type=page&limit=10&search=%7B%22enabled%22:%5B%7B%22operator%22:%22%3D%22,%22value%22:true%7D%5D,%22family%22:%5B%7B%22operator%22:%22IN%22,%22value%22:%5B%22accessories%22%5D%7D%5D%7D&locales=en_US"
+    }
+  },
+  "current_page": 1,
+  "_embedded": {
+    "items": [
+      {
+        "identifier": "empty",
+        "enabled": true,
+        "family": null,
+        "categories": [],
+        "groups": [],
+        "parent": null,
+        "values": [],
+        "created": "2022-02-07T13:40:56+00:00",
+        "updated": "2022-02-07T15:58:20+00:00",
+        "associations": {
+          "PACK": {
+            "products": [],
+            "product_models": [],
+            "groups": []
+          },
+          "UPSELL": {
+            "products": [],
+            "product_models": [],
+            "groups": []
+          },
+          "X_SELL": {
+            "products": [],
+            "product_models": [],
+            "groups": []
+          },
+          "SUBSTITUTION": {
+            "products": [],
+            "product_models": [],
+            "groups": []
+          }
+        },
+        "quantified_associations": {}
+      }
+    ]
+  }
+}

--- a/tests/Integration/MockPimApiTrait.php
+++ b/tests/Integration/MockPimApiTrait.php
@@ -40,6 +40,10 @@ trait MockPimApiTrait
             'https://example.com/api/rest/v1/products/10661721',
         );
         $this->mockPimAPIResponse(
+            'get-product-empty.json',
+            'https://example.com/api/rest/v1/products/empty',
+        );
+        $this->mockPimAPIResponse(
             'get-family-accessories.json',
             'https://example.com/api/rest/v1/families/accessories',
         );

--- a/tests/Integration/Query/FetchProductQueryTest.php
+++ b/tests/Integration/Query/FetchProductQueryTest.php
@@ -61,4 +61,17 @@ class FetchProductQueryTest extends AbstractIntegrationTest
 
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * @test
+     */
+    public function itFetchesAnEmptyProduct(): void
+    {
+        $query = static::getContainer()->get(FetchProductQuery::class);
+        $result = $query->fetch('empty', 'en_US');
+
+        $expected = new Product('empty', '[empty]', []);
+
+        $this->assertEquals($expected, $result);
+    }
 }

--- a/tests/Integration/Query/FetchProductsQueryTest.php
+++ b/tests/Integration/Query/FetchProductsQueryTest.php
@@ -56,4 +56,24 @@ class FetchProductsQueryTest extends AbstractIntegrationTest
 
         $this->assertEquals($expected, $result);
     }
+
+    /**
+     * @test
+     */
+    public function itFetchesEmptyProducts(): void
+    {
+        $this->mockPimAPIResponse(
+            'get-products-empty.json',
+            'https://example.com/api/rest/v1/products?search=%7B%22enabled%22%3A%5B%7B%22operator%22%3A%22%3D%22%2C%22value%22%3Atrue%7D%5D%7D&locales=en_US&limit=10&with_count=false',
+        );
+
+        $query = static::getContainer()->get(FetchProductsQuery::class);
+        $result = $query->fetch('en_US');
+
+        $expected = [
+            new Product('empty', '[empty]', []),
+        ];
+
+        $this->assertEquals($expected, $result);
+    }
 }


### PR DESCRIPTION
Fun fact, by using the REST API, you can create empty products, with only an identifier, no family.

I've added one integration test on each query for such cases, updated the static types and fixed the code accordingly.