### PR TITLE
OCT-33: Changed throw exception to throw 400 instead of 500

### DIFF
--- a/src/Controller/WelcomeAction.php
+++ b/src/Controller/WelcomeAction.php
@@ -8,6 +8,7 @@ use App\Storage\AccessTokenSessionStorage;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\RouterInterface;
 use Twig\Environment as TwigEnvironment;
@@ -31,7 +32,7 @@ final class WelcomeAction
             return new Response($this->twig->render('welcome.html.twig'));
         }
         if (false === \filter_var($pimUrl, FILTER_VALIDATE_URL)) {
-            throw new \LogicException('PIM url is not valid.');
+            throw new BadRequestHttpException('PIM url is not valid.');
         }
 
         $session->set('pim_url', \rtrim((string) $pimUrl, '/'));

--- a/templates/bundles/TwigBundle/Exception/error400.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error400.html.twig
@@ -1,0 +1,13 @@
+{% extends 'base.html.twig' %}
+{% block title %}{{ 'page.error_400.title' | trans }}{% endblock %}
+{% block body %}
+    <div class="error-container">
+        <section class="error">
+            <img class="error__illustration"
+                 src="{{ asset('build/images/error.svg') }}"
+                 alt="{{ 'page.error_400.illustration_alt' | trans }}">
+            <h3 class="error__title">{{ 'page.error_400.error_title' | trans }}</h3>
+            <p class="error__description">{{ exception.message }}</p>
+        </section>
+    </div>
+{% endblock %}

--- a/tests/Integration/Controller/WelcomeActionTest.php
+++ b/tests/Integration/Controller/WelcomeActionTest.php
@@ -37,7 +37,7 @@ class WelcomeActionTest extends AbstractIntegrationTest
     {
         $client = $this->initializeClientWithSession([]);
         $client->request('GET', '/?pim_url=INVALID_URL');
-        $this->assertEquals(Response::HTTP_INTERNAL_SERVER_ERROR, $client->getResponse()->getStatusCode());
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $client->getResponse()->getStatusCode());
     }
 
     /**

--- a/translations/messages.en_US.yaml
+++ b/translations/messages.en_US.yaml
@@ -58,9 +58,9 @@ page:
         description: Please try to connect this App again on the PIM App Store
 
     error_400:
-        title: Error 400 Bad request
-        illustration_alt: Error 400 Bad request
-        error_title: Error 400 Bad request
+        title: Bad request
+        illustration_alt: Bad request
+        error_title: Bad request
 
     error_404:
         title: Page not found

--- a/translations/messages.en_US.yaml
+++ b/translations/messages.en_US.yaml
@@ -57,6 +57,11 @@ page:
         error_title: Something went wrong
         description: Please try to connect this App again on the PIM App Store
 
+    error_400:
+        title: Error 400 Bad request
+        illustration_alt: Error 400 Bad request
+        error_title: Error 400 Bad request
+
     error_404:
         title: Page not found
         illustration_alt: Page not found


### PR DESCRIPTION
Providing an invalid PIM URL generates a 500 error.

This fix converts errors thrown into 400.

A twig template for 400 errors is added. It displays the message embedded with the thrown exception.

![image](https://user-images.githubusercontent.com/7101819/168773765-c3966520-7afa-4bb8-bc7a-ae33f6788624.png)
